### PR TITLE
fix: async_setup_entry

### DIFF
--- a/custom_components/network_scanner/__init__.py
+++ b/custom_components/network_scanner/__init__.py
@@ -9,7 +9,7 @@ async def async_setup(hass, config):
 
 async def async_setup_entry(hass, config_entry):
     """Set up Network Scanner from a config entry."""
-    await hass.config_entries.async_forward_entry_setup(config_entry, "sensor")
+    await hass.config_entries.async_forward_entry_setup(config_entry, ["sensor"])
     return True
 
 async def async_unload_entry(hass, config_entry):

--- a/custom_components/network_scanner/__init__.py
+++ b/custom_components/network_scanner/__init__.py
@@ -9,9 +9,7 @@ async def async_setup(hass, config):
 
 async def async_setup_entry(hass, config_entry):
     """Set up Network Scanner from a config entry."""
-    hass.async_create_task(
-        hass.config_entries.async_forward_entry_setup(config_entry, "sensor")
-    )
+    await hass.config_entries.async_forward_entry_setup(config_entry, "sensor")
     return True
 
 async def async_unload_entry(hass, config_entry):


### PR DESCRIPTION
Fixes issue #11:
Detected code that calls async_forward_entry_setup for integration network_scanner with title: Network Scanner and entry_id: 6e0451e0373edf729796de358888d8e6, during setup without awaiting async_forward_entry_setup, which can cause the setup lock to be released before the setup is done. This will stop working in Home Assistant 2025.1. Please report this issue.