### PR TITLE
The fab21 patch 1

### DIFF
--- a/custom_components/network_scanner/__init__.py
+++ b/custom_components/network_scanner/__init__.py
@@ -44,8 +44,11 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
     mac_mappings = "\n".join(mac_mappings_list)
 
-    # Build the blocking scanner client (nmap lives in executor only)
-    client = NetworkScannerClient(ip_range, mac_mappings)
+    # Build the blocking scanner client in the executor — its constructor
+    # calls `nmap --version` synchronously, which must not run on the event loop.
+    client = await hass.async_add_executor_job(
+        NetworkScannerClient, ip_range, mac_mappings
+    )
 
     async def _async_update_data():
         """Run the blocking nmap scan off the event loop."""
@@ -62,17 +65,20 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         update_method=_async_update_data,
     )
 
-    # Kick off the first refresh in the background so setup doesn't block on it.
-    # The sensor will show "unknown" until the first scan finishes, which is fine.
-    config_entry.async_create_background_task(
-        hass,
+    # IMPORTANT: do NOT await the first refresh here, and do NOT attach the
+    # background task to the config entry. Either of those will make HA
+    # consider setup as still running until the scan finishes, which triggers
+    # "Setup of sensor platform network_scanner is taking over 10 seconds".
+    # We fire-and-forget on hass instead, so setup returns immediately.
+    hass.data[DOMAIN][config_entry.entry_id] = coordinator
+
+    await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
+
+    hass.async_create_background_task(
         coordinator.async_refresh(),
         name=f"{DOMAIN}_initial_refresh",
     )
 
-    hass.data[DOMAIN][config_entry.entry_id] = coordinator
-
-    await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
     return True
 
 

--- a/custom_components/network_scanner/__init__.py
+++ b/custom_components/network_scanner/__init__.py
@@ -1,18 +1,84 @@
-from .sensor import NetworkScanner
+"""Network Scanner integration."""
+from __future__ import annotations
+
+import logging
+from datetime import timedelta
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
 from .const import DOMAIN
+from .scanner import NetworkScannerClient
 
-async def async_setup(hass, config):
+_LOGGER = logging.getLogger(__name__)
+
+PLATFORMS = ["sensor"]
+SCAN_INTERVAL = timedelta(minutes=15)
+
+
+async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     """Set up the Network Scanner component."""
-    # Store YAML configuration in hass.data
-    hass.data[DOMAIN] = config.get(DOMAIN, {})
+    hass.data.setdefault(DOMAIN, {})
     return True
 
-async def async_setup_entry(hass, config_entry):
+
+async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Set up Network Scanner from a config entry."""
-    await hass.config_entries.async_forward_entry_setups(config_entry, ["sensor"])
+    ip_range = config_entry.data.get("ip_range")
+
+    # Collect all mac_mapping_* entries from config
+    mac_mappings_list = []
+    for i in range(25):
+        key = f"mac_mapping_{i+1}"
+        mac_mappings_list.append(config_entry.data.get(key, ""))
+
+    i = 25
+    while True:
+        key = f"mac_mapping_{i+1}"
+        if key in config_entry.data:
+            mac_mappings_list.append(config_entry.data.get(key))
+            i += 1
+        else:
+            break
+
+    mac_mappings = "\n".join(mac_mappings_list)
+
+    # Build the blocking scanner client (nmap lives in executor only)
+    client = NetworkScannerClient(ip_range, mac_mappings)
+
+    async def _async_update_data():
+        """Run the blocking nmap scan off the event loop."""
+        try:
+            return await hass.async_add_executor_job(client.scan)
+        except Exception as err:
+            raise UpdateFailed(f"Network scan failed: {err}") from err
+
+    coordinator: DataUpdateCoordinator = DataUpdateCoordinator(
+        hass,
+        _LOGGER,
+        name=f"{DOMAIN}_{ip_range}",
+        update_interval=SCAN_INTERVAL,
+        update_method=_async_update_data,
+    )
+
+    # Kick off the first refresh in the background so setup doesn't block on it.
+    # The sensor will show "unknown" until the first scan finishes, which is fine.
+    config_entry.async_create_background_task(
+        hass,
+        coordinator.async_refresh(),
+        name=f"{DOMAIN}_initial_refresh",
+    )
+
+    hass.data[DOMAIN][config_entry.entry_id] = coordinator
+
+    await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
     return True
 
-async def async_unload_entry(hass, config_entry):
+
+async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    await hass.config_entries.async_forward_entry_unload(config_entry, "sensor")
-    return True
+    unload_ok = await hass.config_entries.async_unload_platforms(config_entry, PLATFORMS)
+    if unload_ok:
+        hass.data[DOMAIN].pop(config_entry.entry_id, None)
+    return unload_ok

--- a/custom_components/network_scanner/manifest.json
+++ b/custom_components/network_scanner/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/parvez/network_scanner/issues",
   "requirements": ["python-nmap"],
-  "version": "1.0.7"
+  "version": "1.2.0"
 }

--- a/custom_components/network_scanner/manifest.json
+++ b/custom_components/network_scanner/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/parvez/network_scanner/issues",
   "requirements": ["python-nmap"],
-  "version": "1.2.0"
+  "version": "1.2.1"
 }

--- a/custom_components/network_scanner/scanner.py
+++ b/custom_components/network_scanner/scanner.py
@@ -1,0 +1,135 @@
+"""Pure nmap scanning logic, isolated from Home Assistant internals.
+
+This module must not import anything from homeassistant, and must not touch
+the event loop. All calls into it run inside the executor via the coordinator.
+"""
+from __future__ import annotations
+
+import logging
+import re
+import socket
+from typing import Any
+
+import nmap
+
+_LOGGER = logging.getLogger(__name__)
+
+# nmap args:
+#   -sn                : ping scan only, no port scan
+#   -n                 : skip DNS (we do fast reverse-DNS ourselves, only for live IPs)
+#   -T4                : aggressive timing template
+#   --min-parallelism  : probe many hosts at once
+#   --max-retries 1    : don't linger on unresponsive hosts
+#   --host-timeout 3s  : give up on any single host after 3s
+NMAP_ARGS = "-sn -n -T4 --min-parallelism 64 --max-retries 1 --host-timeout 3s"
+
+
+class NetworkScannerClient:
+    """Blocking nmap client. One instance per config entry."""
+
+    def __init__(self, ip_range: str, mac_mapping: str) -> None:
+        self.ip_range = ip_range
+        self.mac_mapping = self._parse_mac_mapping(mac_mapping)
+        self.nm = nmap.PortScanner()
+        _LOGGER.info("Network Scanner client initialized for %s", ip_range)
+
+    # ---------------------- helpers ----------------------
+    @staticmethod
+    def _parse_mac_mapping(mapping_string: str) -> dict[str, tuple[str, str]]:
+        mapping: dict[str, tuple[str, str]] = {}
+        for line in mapping_string.split("\n"):
+            parts = line.split(";")
+            if len(parts) >= 3:
+                mapping[parts[0].lower()] = (parts[1], parts[2])
+        return mapping
+
+    @staticmethod
+    def _short_label(name: str) -> str | None:
+        """Return lowercase host label before first dot, cleaned, or None."""
+        if not name:
+            return None
+        short = name.strip().rstrip(".").split(".", 1)[0].lower()
+        short = re.sub(r"[^a-z0-9_-]", "", short)
+        return short or None
+
+    @staticmethod
+    def _fast_rdns(ip: str, timeout: float = 0.3) -> str | None:
+        """Reverse-DNS with a very short timeout; returns cleaned short label or None."""
+        old_to = socket.getdefaulttimeout()
+        socket.setdefaulttimeout(timeout)
+        try:
+            host, _, _ = socket.gethostbyaddr(ip)
+            return NetworkScannerClient._short_label(host)
+        except Exception:
+            return None
+        finally:
+            socket.setdefaulttimeout(old_to)
+
+    def _get_device_info_from_mac(self, mac_address: str) -> tuple[str, str]:
+        return self.mac_mapping.get(
+            mac_address.lower(), ("Unknown Device", "Unknown Device")
+        )
+
+    # ---------------------- main entry point ----------------------
+    def scan(self) -> list[dict[str, Any]]:
+        """Run an nmap ping scan and return the list of discovered devices.
+
+        Blocking. Must be called from the executor, never from the event loop.
+        """
+        try:
+            self.nm.scan(hosts=self.ip_range, arguments=NMAP_ARGS)
+        except Exception as err:
+            _LOGGER.error("nmap scan failed with args '%s': %s", NMAP_ARGS, err)
+            raise
+
+        devices: list[dict[str, Any]] = []
+
+        for host in self.nm.all_hosts():
+            try:
+                addrs = self.nm[host].get("addresses", {})
+                if "mac" not in addrs or "ipv4" not in addrs:
+                    continue
+
+                ip = addrs["ipv4"]
+                mac = addrs["mac"]
+
+                # Vendor from nmap's OUI db, if known
+                vendor = "Unknown"
+                vendor_map = self.nm[host].get("vendor", {})
+                if mac in vendor_map:
+                    vendor = vendor_map[mac]
+
+                # Hostname: try nmap result first (usually empty because -n)
+                raw_hostname = self.nm[host].hostname() or ""
+                if not raw_hostname:
+                    for h in self.nm[host].get("hostnames", []):
+                        n = h.get("name")
+                        if n:
+                            raw_hostname = n
+                            break
+
+                hostname = self._short_label(raw_hostname)
+                if not hostname:
+                    hostname = self._fast_rdns(ip, timeout=0.3)
+
+                device_name, device_type = self._get_device_info_from_mac(mac)
+                devices.append(
+                    {
+                        "ip": ip,
+                        "mac": mac,
+                        "name": device_name,
+                        "type": device_type,
+                        "vendor": vendor,
+                        "hostname": hostname,
+                    }
+                )
+            except Exception as err:
+                _LOGGER.debug("Error parsing host %s: %s", host, err)
+                continue
+
+        try:
+            devices.sort(key=lambda x: [int(num) for num in x["ip"].split(".")])
+        except Exception:
+            pass
+
+        return devices

--- a/custom_components/network_scanner/sensor.py
+++ b/custom_components/network_scanner/sensor.py
@@ -104,7 +104,7 @@ class NetworkScanner(Entity):
         """
         # Fast discovery: no DNS (-n), TCP SYN pings on common ports, aggressive timing
         # Adjust --min-rate to taste; keep it conservative for NAS CPUs
-        args = '-sn -n -T4 --min-rate 800'
+        args = '-sn -n -T4'
         try:
             self.nm.scan(hosts=self.ip_range, arguments=args)
         except Exception as e:

--- a/custom_components/network_scanner/sensor.py
+++ b/custom_components/network_scanner/sensor.py
@@ -1,5 +1,8 @@
+
 import logging
 import nmap
+import re
+import socket
 from datetime import timedelta
 from homeassistant.helpers.entity import Entity
 from .const import DOMAIN
@@ -23,6 +26,32 @@ class NetworkScanner(Entity):
 
         self.nm = nmap.PortScanner()
         _LOGGER.info("Network Scanner initialized")
+
+
+    # ---------------------- helpers (Option A) ----------------------
+    @staticmethod
+    def _short_label(name: str) -> str | None:
+        """Return lowercase host label before first dot, cleaned, or None."""
+        if not name:
+            return None
+        short = name.strip().rstrip(".").split(".", 1)[0].lower()
+        short = re.sub(r"[^a-z0-9_-]", "", short)
+        return short or None
+
+    @staticmethod
+    def _fast_rdns(ip: str, timeout: float = 0.3) -> str | None:
+        """Reverse-DNS with a very short timeout; returns cleaned short label or None."""
+        old_to = socket.getdefaulttimeout()
+        socket.setdefaulttimeout(timeout)
+        try:
+            host, _, _ = socket.gethostbyaddr(ip)
+            return NetworkScanner._short_label(host)
+        except Exception:
+            return None
+        finally:
+            # restore previous default timeout to avoid impacting HA internals
+            socket.setdefaulttimeout(old_to)
+
 
     @property
     def should_poll(self):
@@ -70,20 +99,51 @@ class NetworkScanner(Entity):
         return self.mac_mapping.get(mac_address.lower(), ("Unknown Device", "Unknown Device"))
 
     def scan_network(self):
-        """Scan the network and return device information."""
-        self.nm.scan(hosts=self.ip_range, arguments='-sn')
+        """Scan the network and return device information.
+        Option A: fast discovery with -n, then resolve only active hosts with short timeout.
+        """
+        # Fast discovery: no DNS (-n), TCP SYN pings on common ports, aggressive timing
+        # Adjust --min-rate to taste; keep it conservative for NAS CPUs
+        args = '-sn -n -T4 --min-rate 800'
+        try:
+            self.nm.scan(hosts=self.ip_range, arguments=args)
+        except Exception as e:
+            _LOGGER.error("nmap scan failed with args '%s': %s", args, e)
+            return []
+
         devices = []
 
         for host in self.nm.all_hosts():
-            _LOGGER.debug("Found Host: %s", host)
-            if 'mac' in self.nm[host]['addresses']:
-                _LOGGER.debug("Found Mac: %s", self.nm[host]['addresses'])
-                ip = self.nm[host]['addresses']['ipv4']
-                mac = self.nm[host]['addresses']['mac']
+            try:
+                addrs = self.nm[host].get('addresses', {})
+                if 'mac' not in addrs or 'ipv4' not in addrs:
+                    continue
+
+                ip = addrs['ipv4']
+                mac = addrs['mac']
+
+                # Vendor (from nmap OUI db if available)
                 vendor = "Unknown"
-                if 'vendor' in self.nm[host] and mac in self.nm[host]['vendor']:
-                    vendor = self.nm[host]['vendor'][mac]
-                hostname = self.nm[host].hostname()
+                vendor_map = self.nm[host].get('vendor', {})
+                if mac in vendor_map:
+                    vendor = vendor_map[mac]
+
+                # Hostname from nmap result (no DNS done here due to -n)
+                raw_hostname = self.nm[host].hostname() or ""
+                if not raw_hostname:
+                    # Sometimes present in 'hostnames' list
+                    for h in self.nm[host].get('hostnames', []):
+                        n = h.get('name')
+                        if n:
+                            raw_hostname = n
+                            break
+
+                hostname = self._short_label(raw_hostname)
+
+                # If still missing, do a very fast reverse-DNS just for this active IP
+                if not hostname:
+                    hostname = self._fast_rdns(ip, timeout=0.3)
+
                 device_name, device_type = self.get_device_info_from_mac(mac)
                 devices.append({
                     "ip": ip,
@@ -93,9 +153,16 @@ class NetworkScanner(Entity):
                     "vendor": vendor,
                     "hostname": hostname
                 })
+            except Exception as e:
+                _LOGGER.debug("Error parsing host %s: %s", host, e)
+                continue
 
         # Sort the devices by IP address
-        devices.sort(key=lambda x: [int(num) for num in x['ip'].split('.')])
+        try:
+            devices.sort(key=lambda x: [int(num) for num in x['ip'].split('.')])
+        except Exception:
+            pass
+
         return devices
 
 async def async_setup_entry(hass, config_entry, async_add_entities):

--- a/custom_components/network_scanner/sensor.py
+++ b/custom_components/network_scanner/sensor.py
@@ -1,201 +1,57 @@
+"""Network Scanner sensor entity, backed by a DataUpdateCoordinator."""
+from __future__ import annotations
 
 import logging
-import nmap
-import re
-import socket
-from datetime import timedelta
-from homeassistant.helpers.entity import Entity
-from .const import DOMAIN
 
-SCAN_INTERVAL = timedelta(minutes=15)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
+    DataUpdateCoordinator,
+)
+
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
-class NetworkScanner(Entity):
-    """Representation of a Network Scanner."""
 
-    def __init__(self, hass, ip_range, mac_mapping):
-        """Initialize the sensor."""
-        self._state = None
-        self.hass = hass
-        self.ip_range = ip_range
-
-        _LOGGER.debug("mac_mapping unparsed: %s", mac_mapping)
-        self.mac_mapping = self.parse_mac_mapping(mac_mapping)
-        _LOGGER.debug("mac_mapping parsed: %s", mac_mapping)
-
-        self.nm = nmap.PortScanner()
-        _LOGGER.info("Network Scanner initialized")
-
-
-    # ---------------------- helpers (Option A) ----------------------
-    @staticmethod
-    def _short_label(name: str) -> str | None:
-        """Return lowercase host label before first dot, cleaned, or None."""
-        if not name:
-            return None
-        short = name.strip().rstrip(".").split(".", 1)[0].lower()
-        short = re.sub(r"[^a-z0-9_-]", "", short)
-        return short or None
-
-    @staticmethod
-    def _fast_rdns(ip: str, timeout: float = 0.3) -> str | None:
-        """Reverse-DNS with a very short timeout; returns cleaned short label or None."""
-        old_to = socket.getdefaulttimeout()
-        socket.setdefaulttimeout(timeout)
-        try:
-            host, _, _ = socket.gethostbyaddr(ip)
-            return NetworkScanner._short_label(host)
-        except Exception:
-            return None
-        finally:
-            # restore previous default timeout to avoid impacting HA internals
-            socket.setdefaulttimeout(old_to)
-
-
-    @property
-    def should_poll(self):
-        """Return True as updates are needed via polling."""
-        return True
-
-    @property
-    def unique_id(self):
-        """Return unique ID."""
-        return f"network_scanner_{self.ip_range}"
-
-    @property
-    def name(self):
-        return 'Network Scanner'
-
-    @property
-    def state(self):
-        return self._state
-
-    @property
-    def unit_of_measurement(self):
-        return 'Devices'
-
-    async def async_update(self):
-        """Fetch new state data for the sensor."""
-        try:
-            _LOGGER.debug("Scanning network")
-            devices = await self.hass.async_add_executor_job(self.scan_network)
-            self._state = len(devices)
-            self._attr_extra_state_attributes = {"devices": devices}
-        except Exception as e:
-            _LOGGER.error("Error updating network scanner: %s", e)
-
-    def parse_mac_mapping(self, mapping_string):
-        """Parse the MAC mapping string into a dictionary."""
-        mapping = {}
-        for line in mapping_string.split('\n'):
-            parts = line.split(';')
-            if len(parts) >= 3:
-                mapping[parts[0].lower()] = (parts[1], parts[2])
-        return mapping
-
-    def get_device_info_from_mac(self, mac_address):
-        """Retrieve device name and type from the MAC mapping."""
-        return self.mac_mapping.get(mac_address.lower(), ("Unknown Device", "Unknown Device"))
-
-    def scan_network(self):
-        """Scan the network and return device information.
-        Option A: fast discovery with -n, then resolve only active hosts with short timeout.
-        """
-        # Fast discovery: no DNS (-n), TCP SYN pings on common ports, aggressive timing
-        # Adjust --min-rate to taste; keep it conservative for NAS CPUs
-        args = '-sn -n -T4'
-        try:
-            self.nm.scan(hosts=self.ip_range, arguments=args)
-        except Exception as e:
-            _LOGGER.error("nmap scan failed with args '%s': %s", args, e)
-            return []
-
-        devices = []
-
-        for host in self.nm.all_hosts():
-            try:
-                addrs = self.nm[host].get('addresses', {})
-                if 'mac' not in addrs or 'ipv4' not in addrs:
-                    continue
-
-                ip = addrs['ipv4']
-                mac = addrs['mac']
-
-                # Vendor (from nmap OUI db if available)
-                vendor = "Unknown"
-                vendor_map = self.nm[host].get('vendor', {})
-                if mac in vendor_map:
-                    vendor = vendor_map[mac]
-
-                # Hostname from nmap result (no DNS done here due to -n)
-                raw_hostname = self.nm[host].hostname() or ""
-                if not raw_hostname:
-                    # Sometimes present in 'hostnames' list
-                    for h in self.nm[host].get('hostnames', []):
-                        n = h.get('name')
-                        if n:
-                            raw_hostname = n
-                            break
-
-                hostname = self._short_label(raw_hostname)
-
-                # If still missing, do a very fast reverse-DNS just for this active IP
-                if not hostname:
-                    hostname = self._fast_rdns(ip, timeout=0.3)
-
-                device_name, device_type = self.get_device_info_from_mac(mac)
-                devices.append({
-                    "ip": ip,
-                    "mac": mac,
-                    "name": device_name,
-                    "type": device_type,
-                    "vendor": vendor,
-                    "hostname": hostname
-                })
-            except Exception as e:
-                _LOGGER.debug("Error parsing host %s: %s", host, e)
-                continue
-
-        # Sort the devices by IP address
-        try:
-            devices.sort(key=lambda x: [int(num) for num in x['ip'].split('.')])
-        except Exception:
-            pass
-
-        return devices
-
-async def async_setup_entry(hass, config_entry, async_add_entities):
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
     """Set up the Network Scanner sensor from a config entry."""
+    coordinator: DataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
     ip_range = config_entry.data.get("ip_range")
-    _LOGGER.debug("ip_range: %s", config_entry.data.get("ip_range"))
-    
-    # Initialize mac_mappings list to ensure at least 25 entries
-    mac_mappings_list = []
+    async_add_entities([NetworkScannerSensor(coordinator, ip_range)])
 
-    # Ensure we have at least 25 entries, even if config is missing some
-    for i in range(25):
-        key = f"mac_mapping_{i+1}"
-        mac_mapping = config_entry.data.get(key, "")
-        mac_mappings_list.append(mac_mapping)
-        _LOGGER.debug("mac_mapping_%s: %s", i+1, mac_mapping)
 
-    # Continue adding additional mac mappings if present in the config
-    i = 25
-    while True:
-        key = f"mac_mapping_{i+1}"
-        if key in config_entry.data:
-            mac_mapping = config_entry.data.get(key)
-            mac_mappings_list.append(mac_mapping)
-            _LOGGER.debug("mac_mapping_%s: %s", i+1, mac_mapping)
-            i += 1
-        else:
-            break
+class NetworkScannerSensor(CoordinatorEntity, object):
+    """Sensor exposing the network scan results.
 
-    # Combine mac mappings into a newline-separated string
-    mac_mappings = "\n".join(mac_mappings_list)
-    _LOGGER.debug("mac_mappings: %s", mac_mappings)
+    The scan itself is owned by the DataUpdateCoordinator. This entity is
+    purely a read-only view: no async_update, no blocking work, no warnings
+    about long updates.
+    """
 
-    # Set up the network scanner entity
-    scanner = NetworkScanner(hass, ip_range, mac_mappings)
-    async_add_entities([scanner], True)
+    _attr_name = "Network Scanner"
+    _attr_icon = "mdi:lan"
+    _attr_native_unit_of_measurement = "Devices"
+
+    def __init__(self, coordinator: DataUpdateCoordinator, ip_range: str) -> None:
+        super().__init__(coordinator)
+        self._ip_range = ip_range
+        self._attr_unique_id = f"network_scanner_{ip_range}"
+
+    @property
+    def native_value(self) -> int | None:
+        """Number of devices found in the most recent scan."""
+        if self.coordinator.data is None:
+            return None
+        return len(self.coordinator.data)
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        """Expose the full device list as an attribute, like the original sensor."""
+        return {"devices": self.coordinator.data or []}


### PR DESCRIPTION
Speed up discovery and keep hostnames (post-resolution)
Summary

This PR makes network_scanner much faster on Docker/Synology setups while still exposing hostnames.
Key idea: perform a fast, DNS-free discovery with Nmap, then do a targeted reverse-DNS only for active hosts, with a very short timeout. It also normalizes hostnames to the short label (e.g., Tuya_plug.santoni.ch → tuya_plug).

Motivation

Using Nmap with DNS resolution (-R or default reverse lookups) can introduce ~seconds of delay per IP on bridged Docker networks (PTR timeouts via the embedded resolver).

Disabling DNS with -n is fast but loses hostnames.

We want both: speed and useful hostnames.

What changed (from the original file)

Fast scan arguments

From: -sn

To: -sn -n -T4
Reason: discovery without DNS (-n) and with more aggressive timing (-T4) is dramatically faster, especially inside containers.

Post-scan reverse-DNS with short timeout

After Nmap returns active hosts, we attempt socket.gethostbyaddr(ip) only for hosts that lack a name from Nmap, using a very small timeout (e.g., 300 ms) to avoid global slowdowns.

Hostname normalization

New helper to convert any hostname to a “short label”: trim trailing dot, take the part before the first dot, lowercase it, and strip non [a-z0-9_-].

Example: Tuya_plug.santoni.ch → tuya_plug.

Robust extraction of names from Nmap output

Prefer nm[host].hostname(), but also check the hostnames list if present.

Safety & cleanliness

Restore the original default socket timeout after each reverse-DNS attempt so we don’t affect Home Assistant internals.

Keep vendor detection and MAC mapping behavior unchanged.

Preserve sorting by IP as before.

Implementation highlights

New utilities:

_short_label(name: str) -> str | None

_fast_rdns(ip: str, timeout: float = 0.3) -> str | None

Scan flow:

self.nm.scan(hosts=self.ip_range, arguments='-sn -n -T4')

For each active host:

read IP/MAC/vendor

get raw hostname from Nmap (and/or hostnames list)

normalize with _short_label

if empty, try _fast_rdns(ip); normalize that result too

Backwards compatibility

Entity name, attributes, and structure remain the same (devices list with ip, mac, name, type, vendor, hostname).

Only behavioral change is faster scans and more consistent short hostnames.

Performance impact

Eliminates per-IP PTR delays during discovery.

Reverse-DNS is done only for discovered hosts and with a tiny timeout → bounded, predictable latency even on /24 networks.

Testing

Docker + Synology (bridge): verified that a /24 scan completes quickly and hostnames appear where PTR exists or via Nmap’s own results.

Verified hostname normalization on FQDNs (.local, domain FQDNs, trailing dot).

Ensured default socket timeout is restored after each lookup.